### PR TITLE
load patch to fix performance of Asciidoctor.js 2 on Node.js 10

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -29,7 +29,8 @@ asciidoc:
     cloud: false
     tabs: tabs
   extensions:
-    - "@djencks/asciidoctor-tabset-block"
+  - ./lib/asciidoctor-performance-patch.js
+  - "@djencks/asciidoctor-tabset-block"
 output:
   clean: true
   dir: build/software

--- a/lib/asciidoctor-performance-patch.js
+++ b/lib/asciidoctor-performance-patch.js
@@ -1,0 +1,23 @@
+'use strict'
+
+// Fixes a performance issue with Asciidoctor.js 2 when used with Node.js 10
+module.exports = () => {
+  const Asciidoctor = global.Opal.Asciidoctor
+
+  Asciidoctor.Reader.prototype.$shift = function () {
+    this.lineno++
+    if (this.look_ahead) this.look_ahead--
+    return this.lines.shift()
+  }
+
+  Asciidoctor.PreprocessorReader.prototype.$shift = function () {
+    this.lineno++
+    if (this.look_ahead) this.look_ahead--
+    const line = this.lines.shift()
+    if (this.unescape_next_line) {
+      this.unescape_next_line = false
+      return line.substr(1)
+    }
+    return line
+  }
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,8 @@
 [build.environment]
 CI = "true"
 NODE_VERSION = "10"
-# WARNING netlify-build ignores NPM_FLAGS when installing plugins, so use low-level NPM_CONFIG_ flag instead
-#NPM_FLAGS = "--no-optional"
 NPM_CONFIG_OPTIONAL = "false"
 ANTORA_CACHE_DIR = "node_modules/.cache/antora"
-NODE_OPTIONS = "--max-old-space-size=4096"
+
+[build]
+command = "node_modules/.bin/antora antora-playbook.yml --stacktrace --log-format=pretty"


### PR DESCRIPTION
Note that this patch will only work with Node.js 10. If used with Node.js 12 or above, it will make the performance even worse.