### PR TITLE
Publishing of 8.8.0.cl docs

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -16,7 +16,7 @@ content:
     start_path: software/
   - url: git@github.com:thoughtspot/thoughtspot-docs.git
   # Cloud docs branches
-    branches: ['8.6.0.cl', '8.7.0.cl']
+    branches: ['8.7.0.cl', '8.8.0.cl']
     start_path: cloud/
   - url: git@github.com:thoughtspot/visual-embed-sdk.git
   # dev docs branches

--- a/netlify.toml
+++ b/netlify.toml
@@ -23,12 +23,6 @@ command = "node_modules/.bin/antora antora-playbook.yml --stacktrace --log-forma
   force = true # COMMENT: redirect all requests for 8.8.0.cl docs to 8.7.0.cl home page until customer cluster upgrade
 
 [[redirects]]
-  from = "https://docs.thoughtspot.com/cloud/8.7.0.cl/*"
-  to = "https://docs.thoughtspot.com/cloud/latest/:splat"
-  status = 301
-  force = true # COMMENT: ensure that we always redirect
-
-[[redirects]]
   from = "https://docs.thoughtspot.com/cloud/8.2.0.cl/*"
   to = "https://docs.thoughtspot.com/cloud/latest/:splat"
   status = 301


### PR DESCRIPTION
- Updated playbook to add 8.8.0.cl branch
- removed 8.7.0.cl to latest global redirect

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>