### PR TITLE
remove 9.9.0.cl from playbook

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -16,7 +16,7 @@ content:
     start_path: software/
   - url: git@github.com:thoughtspot/thoughtspot-docs.git
   # Cloud docs branches
-    branches: ['9.5.0.cl', '9.6.0.cl', '9.7.0.cl', '9.9.0.cl']
+    branches: ['9.5.0.cl', '9.6.0.cl', '9.7.0.cl']
     start_path: cloud/
   - url: git@github.com:thoughtspot/visual-embed-sdk.git
   # dev docs branches

--- a/netlify.toml
+++ b/netlify.toml
@@ -29,6 +29,12 @@ command = "node_modules/.bin/antora antora-playbook.yml --stacktrace --log-forma
   force = true # COMMENT: global redirect for 9.7.0.cl old doc site url to latest cloud
 
 [[redirects]]
+from = "https://docs.thoughtspot.com/cloud/9.7.0.cl/"
+to = "https://docs.thoughtspot.com/cloud/9.7.0.cl/index"
+status = 301
+force = true # COMMENT: global redirect for 9.7.0.cl old doc site url to latest cloud
+
+[[redirects]]
   from = "https://docs.thoughtspot.com/8.4.1.sw.cu1/release/help-center"
   to = "https://docs.thoughtspot.com/software/8.4.1.sw/help-center"
   status = 301
@@ -43,6 +49,16 @@ command = "node_modules/.bin/antora antora-playbook.yml --stacktrace --log-forma
   force = true # COMMENT: ensure that we always redirect
 
 # rewrite to publish older hidden doc version - end
+
+# rewrite to publish gartner at hidden doc version - begin
+
+[[redirects]]
+from = "https://docs.thoughtspot.com/cloud/9.9.0.cl/*"
+to = "https://8-10-0-cl-docs-archive.netlify.app/cloud/9.9.0.cl/:splat"
+status = 200
+force = true # COMMENT: ensure that we always redirect
+
+# rewrite to publish gartner at hidden doc version - end
 
 # rewrites for help - start
 
@@ -380,6 +396,12 @@ command = "node_modules/.bin/antora antora-playbook.yml --stacktrace --log-forma
 
 [[redirects]]
   from = "https://docs.thoughtspot.com/cloud/8.7.0.cl/*"
+  to = "https://docs.thoughtspot.com/cloud/latest/:splat"
+  status = 301
+  force = true # COMMENT: ensure that we always redirect
+
+[[redirects]]
+  from = "https://docs.thoughtspot.com/cloud/9.7.0.cl/*"
   to = "https://docs.thoughtspot.com/cloud/latest/:splat"
   status = 301
   force = true # COMMENT: ensure that we always redirect


### PR DESCRIPTION
Per approval from Vijay Venugopal for Gartner (9.9.0.cl) release delivered on separate site.