### PR TITLE
remove 9.9.0.cl from playbook

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -54,7 +54,7 @@ force = true # COMMENT: global redirect for 9.7.0.cl old doc site url to latest 
 
 [[redirects]]
 from = "https://docs.thoughtspot.com/cloud/9.9.0.cl/*"
-to = "https://8-10-0-cl-docs-archive.netlify.app/cloud/9.9.0.cl/:splat"
+to = "https://ts-9-9-0-cl.netlify.app/cloud/9.9.0.cl/:splat"
 status = 200
 force = true # COMMENT: ensure that we always redirect
 


### PR DESCRIPTION
Per request of Vijay Venugopal for Gartner (9.9.0.cl) release now hosted on separate site.